### PR TITLE
Add types for css-modules

### DIFF
--- a/types/css-modules/css-modules-tests.ts
+++ b/types/css-modules/css-modules-tests.ts
@@ -1,0 +1,21 @@
+import styles from './main.css'
+import * as classNames from 'classnames'
+
+class App {
+    private theme: string
+    constructor(theme: string) {
+        this.theme = theme
+    }
+
+    render() {
+        // as a style tag (using webpack's css-loader)
+        const tpl = `<div style="${styles.toString()}"></div>`
+        // or as scoped unique classes, also latest typescript versions allow prop access using dot like styles.darkUI instead of styles['darkUI']
+        return `
+            <div class="${classNames((this.theme === 'dark')? 
+                styles['darkUI'] : 
+                styles['lightUI'].toString())}">
+            </div>
+        `
+    }
+}

--- a/types/css-modules/index.d.ts
+++ b/types/css-modules/index.d.ts
@@ -1,0 +1,16 @@
+declare module '*.css' {
+    type Stringifyable = {
+        /**
+         * Stringifies the imported stylesheet for use with inline style tags 
+         */
+        toString: () => string
+    }
+    type SelectorNode = {
+        /**
+         * Returns the specific selector from imported stylesheet as string 
+         */
+        [key: string]: string
+    }
+    const styles: SelectorNode & Stringifyable
+    export default styles
+}

--- a/types/css-modules/tsconfig.json
+++ b/types/css-modules/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-modules-tests.ts"
+    ]
+}


### PR DESCRIPTION
Enables users to `import styles from '../main.css'` in TypeScript files.

From there on, assuming user is using `webpack` with `css-loader`, they can also do `styles.toString()` or `classNames(styles.productLabel...` without any squiggly lines.

Also works beautifully with intellisense (both of ops have `string` as return type)

https://github.com/css-modules/css-modules